### PR TITLE
Replace always-red merge alert with a post-merge merge audit

### DIFF
--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -52,6 +52,13 @@ jobs:
     steps:
       - name: Checkout addon code
         uses: actions/checkout@v6
+        with:
+          # Explicit SHA, not the default refs/pull/N/merge: GitHub stops
+          # maintaining that ref once a PR closes, and this job re-runs on a
+          # closed-without-merge event (see the guard above) — a merge ref
+          # that's gone stale or never existed (conflicted PRs) would
+          # otherwise fail checkout and stamp an errored red on the head SHA.
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout review tool
         uses: actions/checkout@v6
@@ -83,9 +90,15 @@ jobs:
     # specifically would silently skip this job for pull_request_target callers.
     if: github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    # No concurrency group on purpose: the closed+merged event fires once per
-    # PR lifetime, so there is nothing to supersede — and cancelling an
-    # in-flight audit would serve no purpose.
+    # No cancel-in-progress: the closed+merged event fires once per PR
+    # lifetime under a single trigger, so there is normally nothing to
+    # supersede. The group still matters for a caller that declares both
+    # pull_request and pull_request_target with `closed` — that fires this
+    # job twice, concurrently; queueing (not cancelling) the second run means
+    # it sees the first run's marker comment and exits via the "already
+    # posted" path instead of double-posting.
+    concurrency:
+      group: "pr-checks-merge-audit-${{ github.repository_id }}-${{ github.event.pull_request.number }}"
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -34,7 +34,15 @@ env:
 jobs:
   review:
     name: Review Code
-    if: github.event.action != 'closed'
+    # Skip only on closed+merged (merge-audit takes over from there). A
+    # closed-without-merge event still runs this job normally, so the real
+    # pass/fail status gets re-posted on the SAME event that closed the PR —
+    # this is what closes the close/reopen bypass a caller could otherwise
+    # hit by adding `closed` to its trigger types without `reopened`: a
+    # `skipped` conclusion counts as passing for required-status purposes,
+    # so skipping on every closed action (merged or not) would let a partner
+    # close a PR blocked by a red check and reopen it green.
+    if: github.event.action != 'closed' || github.event.pull_request.merged != true
     runs-on: ubuntu-latest
     # concurrency must sit at job level: GitHub ignores workflow-level
     # concurrency in a reusable workflow invoked via workflow_call
@@ -68,9 +76,12 @@ jobs:
 
   merge-audit:
     name: Merge audit
-    # Fires only once a PR is actually merged — the caller's pull_request
-    # trigger must list `closed` in its types, otherwise this job never runs.
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    # Fires only once a PR is actually merged — the caller's pull_request (or
+    # pull_request_target) trigger must list `closed` in its types, otherwise
+    # this job never runs. No event_name check: no other event carries a
+    # truthy github.event.pull_request.merged, and gating on 'pull_request'
+    # specifically would silently skip this job for pull_request_target callers.
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     # No concurrency group on purpose: the closed+merged event fires once per
     # PR lifetime, so there is nothing to supersede — and cancelling an
@@ -85,6 +96,11 @@ jobs:
             const MARKER = '<!-- shoptet-merge-audit -->';
             const authorized = process.env.REQUIRED_REVIEWER.split(',').map(reviewer => reviewer.trim());
             const pr = context.payload.pull_request;
+            // Assumes a manual merge: with auto-merge, merged_by is who
+            // *enabled* it, not who triggered the actual merge, and a merge
+            // queue attributes to github-merge-queue[bot] — neither is
+            // expected on private Free-plan partner repos today. Revisit if
+            // auto-merge or merge queues become available to partners.
             const mergedBy = pr.merged_by?.login ?? 'unknown';
 
             if (authorized.includes(mergedBy)) {
@@ -103,7 +119,9 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: pr.number,
                 });
-                if (existing.some(comment => comment.body?.includes(MARKER))) {
+                // Author-checked so a partner can't pre-suppress the audit
+                // comment by posting an ordinary comment containing the marker.
+                if (existing.some(comment => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(MARKER))) {
                   console.log('Audit comment already present — not posting again.');
                   return;
                 }
@@ -120,30 +138,39 @@ jobs:
 
             // Hotfix exception: a partner may merge an urgent fix themselves,
             // provided the branch is named hotfix/* and the diff stays inside
-            // the allowed path. Review happens retroactively.
+            // the allowed path(s). Review happens retroactively. Same rule
+            // grammar as PROTECTED_PATHS above: comma-separated, an entry
+            // ending in '/' matches the whole directory, anything else is an
+            // exact file.
             const prefix = process.env.HOTFIX_BRANCH_PREFIX;
-            const allowedPath = process.env.HOTFIX_ALLOWED_PATH;
+            const allowedPathSpec = process.env.HOTFIX_ALLOWED_PATH;
+            const allowedRules = allowedPathSpec.split(',').map(rule => rule.trim()).filter(Boolean);
+            const isAllowed = (name) => allowedRules.some(rule =>
+              rule.endsWith('/') ? name.startsWith(rule) : name === rule
+            );
             const isHotfixBranch = pr.head.ref.startsWith(prefix);
             let outsideFiles = [];
+            let scopeUnverifiable = false;
             if (isHotfixBranch) {
               const files = await github.paginate(github.rest.pulls.listFiles, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number
               });
-              outsideFiles = [...new Set(files
-                .flatMap(file => file.previous_filename ? [file.filename, file.previous_filename] : [file.filename])
-                .filter(name => !name.startsWith(allowedPath)))];
               // the API lists at most 3000 files — beyond that the scope cannot
               // be verified, so fail closed instead of waving the PR through
               if (files.length >= 3000) {
-                outsideFiles.push(`(${files.length}+ changed files — scope cannot be verified)`);
+                scopeUnverifiable = true;
+              } else {
+                outsideFiles = [...new Set(files
+                  .flatMap(file => file.previous_filename ? [file.filename, file.previous_filename] : [file.filename])
+                  .filter(name => !isAllowed(name)))];
               }
             }
 
-            if (isHotfixBranch && outsideFiles.length === 0) {
+            if (isHotfixBranch && !scopeUnverifiable && outsideFiles.length === 0) {
               await postCommentOnce([
-                `🔥 **Hotfix merged by @${mergedBy} without prior Shoptet review** (branch \`${pr.head.ref}\`, changes limited to \`${allowedPath}\`).`,
+                `🔥 **Hotfix merged by @${mergedBy} without prior Shoptet review** (branch \`${pr.head.ref}\`, changes limited to \`${allowedPathSpec}\`).`,
                 '',
                 `${authorized.map(account => '@' + account).join(', ')} please review this change retroactively — if it does not hold up, revert it.`,
               ].join('\n'));
@@ -153,9 +180,11 @@ jobs:
 
             const shownOutside = outsideFiles.slice(0, 20).join(', ')
               + (outsideFiles.length > 20 ? ` — and ${outsideFiles.length - 20} more` : '');
-            const reason = isHotfixBranch
-              ? `the branch has the \`${prefix}\` prefix but the PR touches files outside \`${allowedPath}\`: ${shownOutside} — the hotfix exception covers only changes inside \`${allowedPath}\``
-              : `only hotfixes (branch \`${prefix}*\`, changes limited to \`${allowedPath}\`) may be merged by partners`;
+            const reason = scopeUnverifiable
+              ? `the PR has too many changed files to verify — scope cannot be verified, so the hotfix exception cannot be applied`
+              : isHotfixBranch
+                ? `the branch has the \`${prefix}\` prefix but the PR touches files outside \`${allowedPathSpec}\`: ${shownOutside} — the hotfix exception covers only changes inside \`${allowedPathSpec}\``
+                : `only hotfixes (branch \`${prefix}*\`, changes limited to \`${allowedPathSpec}\`) may be merged by partners`;
 
             await postCommentOnce([
               `⚠️ **This pull request was merged by @${mergedBy}, who is not a Shoptet reviewer.**`,
@@ -167,7 +196,9 @@ jobs:
 
   files-check:
     name: File Protection Check
-    if: github.event.action != 'closed'
+    # See the "review" job above: closed-without-merge must still run this
+    # job, or a partner could close+reopen past a red check.
+    if: github.event.action != 'closed' || github.event.pull_request.merged != true
     runs-on: ubuntu-latest
     concurrency:
       group: "pr-checks-files-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"
@@ -186,6 +217,13 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number
             });
+
+            // the API lists at most 3000 files — beyond that protection cannot
+            // be verified, so fail closed instead of waving the PR through
+            if (files.length >= 3000) {
+              console.error(`Cannot verify protected paths: PR has ${files.length}+ changed files — scope cannot be verified`);
+              process.exit(1);
+            }
 
             const rules = process.env.PROTECTED_PATHS.split(',').map(rule => rule.trim()).filter(Boolean);
             const isProtected = (name) => rules.some(rule =>
@@ -206,7 +244,9 @@ jobs:
 
   collaborators-check:
     name: Shoptet reviewers assigned
-    if: github.event.action != 'closed'
+    # See the "review" job above: closed-without-merge must still run this
+    # job, or a partner could close+reopen past a red check.
+    if: github.event.action != 'closed' || github.event.pull_request.merged != true
     runs-on: ubuntu-latest
     concurrency:
       group: "pr-checks-collaborators-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"

--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const MARKER = '<!-- shoptet-merge-audit -->';
             const authorized = process.env.REQUIRED_REVIEWER.split(',').map(reviewer => reviewer.trim());
             const pr = context.payload.pull_request;
             const mergedBy = pr.merged_by?.login ?? 'unknown';
@@ -81,6 +82,32 @@ jobs:
             if (authorized.includes(mergedBy)) {
               console.log(`Merged by ${mergedBy} — authorized Shoptet reviewer.`);
               return;
+            }
+
+            // The comment is best-effort and must never decide the audit
+            // outcome: a caller granting less than pull-requests: write would
+            // otherwise turn even a legitimate hotfix red with an API error.
+            // The marker keeps job re-runs from posting duplicates.
+            async function postCommentOnce(body) {
+              try {
+                const existing = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                });
+                if (existing.some(comment => comment.body?.includes(MARKER))) {
+                  console.log('Audit comment already present — not posting again.');
+                  return;
+                }
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: body + '\n' + MARKER,
+                });
+              } catch (error) {
+                core.warning(`Could not post the audit comment: ${error.message}`);
+              }
             }
 
             // Hotfix exception: a partner may merge an urgent fix themselves,
@@ -99,38 +126,35 @@ jobs:
               outsideFiles = [...new Set(files
                 .flatMap(file => file.previous_filename ? [file.filename, file.previous_filename] : [file.filename])
                 .filter(name => !name.startsWith(allowedPath)))];
+              // the API lists at most 3000 files — beyond that the scope cannot
+              // be verified, so fail closed instead of waving the PR through
+              if (files.length >= 3000) {
+                outsideFiles.push(`(${files.length}+ changed files — scope cannot be verified)`);
+              }
             }
 
             if (isHotfixBranch && outsideFiles.length === 0) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: [
-                  `🔥 **Hotfix merged by @${mergedBy} without prior Shoptet review** (branch \`${pr.head.ref}\`, changes limited to \`${allowedPath}\`).`,
-                  '',
-                  `${authorized.map(account => '@' + account).join(', ')} please review this change retroactively — if it does not hold up, revert it.`,
-                ].join('\n'),
-              });
+              await postCommentOnce([
+                `🔥 **Hotfix merged by @${mergedBy} without prior Shoptet review** (branch \`${pr.head.ref}\`, changes limited to \`${allowedPath}\`).`,
+                '',
+                `${authorized.map(account => '@' + account).join(', ')} please review this change retroactively — if it does not hold up, revert it.`,
+              ].join('\n'));
               console.log(`Hotfix merged by ${mergedBy} — flagged for retroactive review.`);
               return;
             }
 
+            const shownOutside = outsideFiles.slice(0, 20).join(', ')
+              + (outsideFiles.length > 20 ? ` — and ${outsideFiles.length - 20} more` : '');
             const reason = isHotfixBranch
-              ? `the branch has the \`${prefix}\` prefix but the PR touches files outside \`${allowedPath}\`: ${outsideFiles.join(', ')} — the hotfix exception covers only changes inside \`${allowedPath}\``
+              ? `the branch has the \`${prefix}\` prefix but the PR touches files outside \`${allowedPath}\`: ${shownOutside} — the hotfix exception covers only changes inside \`${allowedPath}\``
               : `only hotfixes (branch \`${prefix}*\`, changes limited to \`${allowedPath}\`) may be merged by partners`;
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body: [
-                `⚠️ **This pull request was merged by @${mergedBy}, who is not a Shoptet reviewer.**`,
-                '',
-                `Addon changes must be reviewed and merged by ${authorized.map(account => '@' + account).join(', ')} — ${reason}.`,
-                'This merge has been flagged for Shoptet review — unreviewed changes may be reverted and their deployment may be withheld.',
-              ].join('\n'),
-            });
+            await postCommentOnce([
+              `⚠️ **This pull request was merged by @${mergedBy}, who is not a Shoptet reviewer.**`,
+              '',
+              `Addon changes must be reviewed and merged by ${authorized.map(account => '@' + account).join(', ')} — ${reason}.`,
+              'This merge has been flagged for Shoptet review — unreviewed changes may be reverted and their deployment may be withheld.',
+            ].join('\n'));
             core.setFailed(`PR #${pr.number} was merged by ${mergedBy} — only Shoptet reviewers may merge (no qualifying hotfix).`);
 
   files-check:

--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -17,6 +17,11 @@ env:
   REQUIRED_REVIEWER: 'shoptet-addon-reviewer'
   # Entries ending with '/' protect the whole directory, anything else an exact file.
   PROTECTED_PATHS: '.github/workflows/'
+  # Partners may merge urgent fixes themselves when the PR comes from a branch
+  # with this prefix AND touches nothing outside HOTFIX_ALLOWED_PATH — such
+  # merges pass the audit and are flagged for retroactive Shoptet review.
+  HOTFIX_BRANCH_PREFIX: 'hotfix/'
+  HOTFIX_ALLOWED_PATH: 'src/'
 
 jobs:
   review:
@@ -78,6 +83,43 @@ jobs:
               return;
             }
 
+            // Hotfix exception: a partner may merge an urgent fix themselves,
+            // provided the branch is named hotfix/* and the diff stays inside
+            // the allowed path. Review happens retroactively.
+            const prefix = process.env.HOTFIX_BRANCH_PREFIX;
+            const allowedPath = process.env.HOTFIX_ALLOWED_PATH;
+            const isHotfixBranch = pr.head.ref.startsWith(prefix);
+            let outsideFiles = [];
+            if (isHotfixBranch) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number
+              });
+              outsideFiles = [...new Set(files
+                .flatMap(file => file.previous_filename ? [file.filename, file.previous_filename] : [file.filename])
+                .filter(name => !name.startsWith(allowedPath)))];
+            }
+
+            if (isHotfixBranch && outsideFiles.length === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: [
+                  `🔥 **Hotfix merged by @${mergedBy} without prior Shoptet review** (branch \`${pr.head.ref}\`, changes limited to \`${allowedPath}\`).`,
+                  '',
+                  `${authorized.map(account => '@' + account).join(', ')} please review this change retroactively — if it does not hold up, revert it.`,
+                ].join('\n'),
+              });
+              console.log(`Hotfix merged by ${mergedBy} — flagged for retroactive review.`);
+              return;
+            }
+
+            const reason = isHotfixBranch
+              ? `the branch has the \`${prefix}\` prefix but the PR touches files outside \`${allowedPath}\`: ${outsideFiles.join(', ')} — the hotfix exception covers only changes inside \`${allowedPath}\``
+              : `only hotfixes (branch \`${prefix}*\`, changes limited to \`${allowedPath}\`) may be merged by partners`;
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -85,11 +127,11 @@ jobs:
               body: [
                 `⚠️ **This pull request was merged by @${mergedBy}, who is not a Shoptet reviewer.**`,
                 '',
-                `Addon changes must be reviewed and merged by ${authorized.map(account => '@' + account).join(', ')}.`,
+                `Addon changes must be reviewed and merged by ${authorized.map(account => '@' + account).join(', ')} — ${reason}.`,
                 'This merge has been flagged for Shoptet review — unreviewed changes may be reverted and their deployment may be withheld.',
               ].join('\n'),
             });
-            core.setFailed(`PR #${pr.number} was merged by ${mergedBy} — only Shoptet reviewers may merge.`);
+            core.setFailed(`PR #${pr.number} was merged by ${mergedBy} — only Shoptet reviewers may merge (no qualifying hotfix).`);
 
   files-check:
     name: File Protection Check

--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   review:
     name: Review Code
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     # concurrency must sit at job level: GitHub ignores workflow-level
     # concurrency in a reusable workflow invoked via workflow_call
@@ -52,33 +53,47 @@ jobs:
         working-directory: ./
         run: node review-tool/review_tool/review.js src
 
-  merge-check:
-    name: Merge Pull Request alert
+  merge-audit:
+    name: Merge audit
+    # Fires only once a PR is actually merged — the caller's pull_request
+    # trigger must list `closed` in its types, otherwise this job never runs.
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    concurrency:
-      group: "pr-checks-merge-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"
-      cancel-in-progress: true
+    # No concurrency group on purpose: the closed+merged event fires once per
+    # PR lifetime, so there is nothing to supersede — and cancelling an
+    # in-flight audit would serve no purpose.
+    permissions:
+      pull-requests: write
     steps:
-      - name: Get PR author
-        id: pr-info
+      - name: Verify who merged the pull request
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: pr } = await github.rest.pulls.get({
+            const authorized = process.env.REQUIRED_REVIEWER.split(',').map(reviewer => reviewer.trim());
+            const pr = context.payload.pull_request;
+            const mergedBy = pr.merged_by?.login ?? 'unknown';
+
+            if (authorized.includes(mergedBy)) {
+              console.log(`Merged by ${mergedBy} — authorized Shoptet reviewer.`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
+              issue_number: pr.number,
+              body: [
+                `⚠️ **This pull request was merged by @${mergedBy}, who is not a Shoptet reviewer.**`,
+                '',
+                `Addon changes must be reviewed and merged by ${authorized.map(account => '@' + account).join(', ')}.`,
+                'This merge has been flagged for Shoptet review — unreviewed changes may be reverted and their deployment may be withheld.',
+              ].join('\n'),
             });
-            core.setOutput('author', pr.user.login);
-            if (process.env.REQUIRED_REVIEWER.split(',').map(reviewer => reviewer.trim()).includes(pr.user.login)) {
-              console.log(`User ${pr.user.login} is authorized to merge`);
-            } else {
-              console.error(`User ${pr.user.login} is NOT authorized to merge - only Shoptet reviewers can merge`);
-              process.exit(1);
-            }
+            core.setFailed(`PR #${pr.number} was merged by ${mergedBy} — only Shoptet reviewers may merge.`);
 
   files-check:
     name: File Protection Check
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     concurrency:
       group: "pr-checks-files-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"
@@ -117,6 +132,7 @@ jobs:
 
   collaborators-check:
     name: Shoptet reviewers assigned
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     concurrency:
       group: "pr-checks-collaborators-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -41,9 +41,15 @@ on:
     types: [opened, synchronize, reopened, closed]
 jobs:
   checks:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     uses: shoptet/addon-repository-actions-config/.github/workflows/checks.workflow.yml@main
 ```
 
 `closed` must be in the caller's trigger types — GitHub's default (`[opened, synchronize, reopened]`) never fires it — or `merge-audit` never runs and merges go unaudited. `reopened` is not required for safety: the review/files/collaborators jobs re-run on a closed-but-unmerged event too, so a partner cannot close a PR blocked by a red check and reopen it past a stale green one; keep `reopened` only if you also want checks to re-run after a partner reopens a closed PR without a new push.
+
+The `permissions` block matters: a restrictive org/repo default token (`contents: read` only) grants less than the workflow requests, and the merge-audit comment step degrades silently to a warning instead of failing the run — on a qualifying hotfix that means a green check with no retroactive-review ping at all. Declare only one of `pull_request` / `pull_request_target` with `closed` — declaring both fires `merge-audit` twice per merge; the job's own concurrency group queues (not cancels) a duplicate run so it detects the first run's comment instead of double-posting, but there is no reason to wire it that way.
 
 Enforcement of "only Shoptet reviewers may merge" is not this workflow's job — a workflow in a partner-owned repo can only detect and flag, since the partner is admin of their own repo. The actual enforcement (deploy gate, branch protection management) lives in `addon-repository-github-app`, which should mirror this trigger requirement in whatever caller template it distributes.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,20 @@ jobs:
 ```
 
 The resolved package manager is used for the `setup-node` dependency cache, the install step (`npm ci` / `yarn` / `pnpm install --frozen-lockfile`) and the `build --env production` step. Existing Yarn-based addon repositories keep working without any change.
+
+## Pull request checks
+
+`checks.workflow.yml` runs code review, protected-path and required-reviewer checks on every PR, plus a post-merge `merge-audit` job that flags a merge performed by anyone other than `REQUIRED_REVIEWER` (with a retroactive-review exception for `hotfix/*` branches touching only `src/`). Call it with:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+jobs:
+  checks:
+    uses: shoptet/addon-repository-actions-config/.github/workflows/checks.workflow.yml@main
+```
+
+`closed` must be in the caller's trigger types — GitHub's default (`[opened, synchronize, reopened]`) never fires it — or `merge-audit` never runs and merges go unaudited. `reopened` is not required for safety: the review/files/collaborators jobs re-run on a closed-but-unmerged event too, so a partner cannot close a PR blocked by a red check and reopen it past a stale green one; keep `reopened` only if you also want checks to re-run after a partner reopens a closed PR without a new push.
+
+Enforcement of "only Shoptet reviewers may merge" is not this workflow's job — a workflow in a partner-owned repo can only detect and flag, since the partner is admin of their own repo. The actual enforcement (deploy gate, branch protection management) lives in `addon-repository-github-app`, which should mirror this trigger requirement in whatever caller template it distributes.

--- a/tests/run-github-script.js
+++ b/tests/run-github-script.js
@@ -9,6 +9,9 @@
 //              context.payload.pull_request)
 //   files    — array returned when the script paginates pulls.listFiles
 //   reviews  — array returned when the script paginates pulls.listReviews
+//   comments — array returned when the script paginates issues.listComments
+//   commentError — when true, issues.createComment throws, simulating a
+//              token without pull-requests: write
 //
 // The exit code is the test result: 0 = the script finished normally,
 // 1 = the script signalled a policy failure (process.exit(1) / core.setFailed),
@@ -34,7 +37,12 @@ const github = {
     },
     issues: {
       listComments: paged(fixture.comments || []),
-      createComment: async () => ({}),
+      // The body is echoed so tests can assert on what would be posted.
+      createComment: async ({ body }) => {
+        if (fixture.commentError) throw new Error('simulated API failure');
+        console.log(`[createComment] ${body}`);
+        return {};
+      },
     },
   },
   paginate: async (endpoint) => endpoint.__page ?? [],

--- a/tests/test-checks-workflow-scripts.sh
+++ b/tests/test-checks-workflow-scripts.sh
@@ -12,7 +12,7 @@ TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
 ruby -ryaml -e '
-wf, files_js, collab_js = ARGV
+wf, files_js, collab_js, audit_js = ARGV
 jobs = YAML.load_file(wf)["jobs"]
 grab = ->(job, step) {
   s = jobs.fetch(job) { abort "Job \"#{job}\" not found — renamed? Update tests/test-checks-workflow-scripts.sh." }["steps"]
@@ -21,7 +21,8 @@ grab = ->(job, step) {
 }
 File.write(files_js, grab.call("files-check", "Check protected files"))
 File.write(collab_js, grab.call("collaborators-check", "Check required reviewers"))
-' "$WORKFLOW" "$TMP/files.js" "$TMP/collab.js"
+File.write(audit_js, grab.call("merge-audit", "Verify who merged the pull request"))
+' "$WORKFLOW" "$TMP/files.js" "$TMP/collab.js" "$TMP/audit.js"
 
 PASS=0
 FAIL=0
@@ -114,6 +115,64 @@ cat > "$TMP/c5.json" <<'EOF'
   "reviews": [ { "user": { "login": "shoptet-addon-reviewer" }, "state": "COMMENTED" } ] }
 EOF
 run_case "multiple required reviewers combine request + review" "$TMP/collab.js" "$TMP/c5.json" 0
+
+### merge-audit — who merged, hotfix exception, comment idempotence
+
+cat > "$TMP/a1.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/" },
+  "pr": { "number": 7, "merged_by": { "login": "shoptet-addon-reviewer" }, "head": { "ref": "feature/banner" } },
+  "files": [], "comments": [] }
+EOF
+run_case "merge by Shoptet reviewer passes" "$TMP/audit.js" "$TMP/a1.json" 0 'authorized Shoptet reviewer'
+
+cat > "$TMP/a2.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/" },
+  "pr": { "number": 7, "merged_by": { "login": "partner-dev" }, "head": { "ref": "hotfix/broken-banner" } },
+  "files": [ { "filename": "src/banner.js" }, { "filename": "src/style.less" } ],
+  "comments": [] }
+EOF
+run_case "qualified hotfix passes and posts the retro-review comment" "$TMP/audit.js" "$TMP/a2.json" 0 'flagged for retroactive review'
+
+cat > "$TMP/a3.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/" },
+  "pr": { "number": 7, "merged_by": { "login": "partner-dev" }, "head": { "ref": "hotfix/sneaky" } },
+  "files": [ { "filename": "src/banner.js" }, { "filename": "webpack.config.js" } ],
+  "comments": [] }
+EOF
+run_case "hotfix touching files outside src/ fails and names them" "$TMP/audit.js" "$TMP/a3.json" 1 'webpack.config.js'
+
+cat > "$TMP/a4.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/" },
+  "pr": { "number": 7, "merged_by": { "login": "partner-dev" }, "head": { "ref": "feature/banner" } },
+  "files": [ { "filename": "src/banner.js" } ], "comments": [] }
+EOF
+run_case "non-hotfix merge by partner fails" "$TMP/audit.js" "$TMP/a4.json" 1 'only hotfixes'
+
+# the 3000-file fixture is generated, not hand-written
+node -e '
+const files = Array.from({ length: 3000 }, (unused, i) => ({ filename: `src/f${i}.js` }));
+process.stdout.write(JSON.stringify({
+  env: { REQUIRED_REVIEWER: "shoptet-addon-reviewer", HOTFIX_BRANCH_PREFIX: "hotfix/", HOTFIX_ALLOWED_PATH: "src/" },
+  pr: { number: 7, merged_by: { login: "partner-dev" }, head: { ref: "hotfix/huge" } },
+  files, comments: []
+}));' > "$TMP/a5.json"
+run_case "3000-file hotfix fails closed (scope unverifiable)" "$TMP/audit.js" "$TMP/a5.json" 1 'scope cannot be verified'
+
+cat > "$TMP/a6.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/" },
+  "pr": { "number": 7, "merged_by": { "login": "partner-dev" }, "head": { "ref": "hotfix/broken-banner" } },
+  "files": [ { "filename": "src/banner.js" } ],
+  "comments": [ { "body": "older audit comment\n<!-- shoptet-merge-audit -->" } ] }
+EOF
+run_case "re-run with existing marker comment does not post again" "$TMP/audit.js" "$TMP/a6.json" 0 'already present'
+
+cat > "$TMP/a7.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/" },
+  "commentError": true,
+  "pr": { "number": 7, "merged_by": { "login": "partner-dev" }, "head": { "ref": "hotfix/broken-banner" } },
+  "files": [ { "filename": "src/banner.js" } ], "comments": [] }
+EOF
+run_case "comment API failure does not change a passing audit" "$TMP/audit.js" "$TMP/a7.json" 0 'Could not post the audit comment'
 
 echo
 echo "=== $PASS passed, $FAIL failed ==="

--- a/tests/test-checks-workflow-scripts.sh
+++ b/tests/test-checks-workflow-scripts.sh
@@ -78,6 +78,16 @@ cat > "$TMP/f5.json" <<'EOF'
 EOF
 run_case "exact-file rule is not a prefix match" "$TMP/files.js" "$TMP/f5.json" 0
 
+# the 3000-file fixture is generated, not hand-written
+node -e '
+const files = Array.from({ length: 3000 }, (unused, i) => ({ filename: `src/f${i}.js` }));
+process.stdout.write(JSON.stringify({
+  env: { PROTECTED_PATHS: ".github/workflows/" },
+  pr: { number: 1 },
+  files
+}));' > "$TMP/f6.json"
+run_case "3000-file PR fails closed (scope unverifiable)" "$TMP/files.js" "$TMP/f6.json" 1 'scope cannot be verified'
+
 ### collaborators-check — requested reviewers + submitted reviews
 
 cat > "$TMP/c1.json" <<'EOF'
@@ -176,9 +186,24 @@ cat > "$TMP/a6.json" <<'EOF'
 { "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/" },
   "pr": { "number": 7, "merged_by": { "login": "partner-dev" }, "head": { "ref": "hotfix/broken-banner" } },
   "files": [ { "filename": "src/banner.js" } ],
-  "comments": [ { "body": "older audit comment\n<!-- shoptet-merge-audit -->" } ] }
+  "comments": [ { "user": { "login": "github-actions[bot]" }, "body": "older audit comment\n<!-- shoptet-merge-audit -->" } ] }
 EOF
-run_case "re-run with existing marker comment does not post again" "$TMP/audit.js" "$TMP/a6.json" 0 'already present'
+run_case "re-run with existing bot marker comment does not post again" "$TMP/audit.js" "$TMP/a6.json" 0 'already present'
+
+cat > "$TMP/a6b.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/" },
+  "pr": { "number": 7, "merged_by": { "login": "partner-dev" }, "head": { "ref": "hotfix/broken-banner" } },
+  "files": [ { "filename": "src/banner.js" } ],
+  "comments": [ { "user": { "login": "partner-dev" }, "body": "unrelated comment\n<!-- shoptet-merge-audit -->" } ] }
+EOF
+run_case "a partner-authored marker does not pre-suppress the audit comment" "$TMP/audit.js" "$TMP/a6b.json" 0 'flagged for retroactive review'
+
+cat > "$TMP/a8.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/,assets/" },
+  "pr": { "number": 7, "merged_by": { "login": "partner-dev" }, "head": { "ref": "hotfix/broken-banner" } },
+  "files": [ { "filename": "src/banner.js" }, { "filename": "assets/logo.png" } ], "comments": [] }
+EOF
+run_case "HOTFIX_ALLOWED_PATH accepts a comma-separated list, same grammar as PROTECTED_PATHS" "$TMP/audit.js" "$TMP/a8.json" 0 'flagged for retroactive review'
 
 cat > "$TMP/a7.json" <<'EOF'
 { "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer", "HOTFIX_BRANCH_PREFIX": "hotfix/", "HOTFIX_ALLOWED_PATH": "src/" },


### PR DESCRIPTION
## Why

The **"Merge Pull Request alert"** job compares the **PR author** against `REQUIRED_REVIEWER`. Since the author of a partner PR is by definition the partner, the check is **permanently red on every partner PR** — it can never turn green, no matter what anyone does. Verified live on a sandbox partner repo (July 2026 E2E test). Consequences:

- it can never be made a *required* status check — that would block every single merge,
- because it is not required, it does nothing — and a check that is always red actively **trains partners to ignore red checks** (a July 2026 audit found 69 % of merged partner PRs had zero review),
- fundamentally, a PR check runs *before* the merge and therefore **cannot know who will perform the merge** — it is the wrong tool for the "only Shoptet reviewers may merge" policy.

## What this PR changes

- **Removes** the `merge-check` job ("Merge Pull Request alert").
- **Adds** a `merge-audit` job that runs only after a PR is actually merged (`pull_request` event, `action == 'closed' && merged == true`). If the PR was merged by anyone other than an account listed in `REQUIRED_REVIEWER`:
  - it posts an explanatory comment on the merged PR (mentioning the merging user, so they are notified),
  - it fails, leaving a visible red check on the merged PR and generating a notification — an honest, factual signal instead of a permanent false alarm.
  - Merges performed by a Shoptet reviewer pass silently; PRs closed without merging skip the `merge-audit` job entirely (it fires only on closed **and** merged).
- **Guards** the `review`, `files-check` and `collaborators-check` jobs so they skip only on a closed-**and**-merged event (merge-audit takes over from there); a closed-without-merge event still runs them normally, so the real pass/fail status gets re-posted on the same event that closed the PR — this is what closes a close/reopen bypass of required checks a caller could otherwise hit by adding `closed` to its trigger types.

### Caller note (no breakage, but needed for the audit to fire)

GitHub's default `pull_request` types are `[opened, synchronize, reopened]` — **they do not include `closed`**. Callers must extend their trigger for the audit to run:

```yaml
on:
  pull_request:
    types: [opened, synchronize, reopened, closed]
```

Callers that don't add `closed` keep working exactly as before (the new job simply never runs), so this can roll out gradually. `reopened` is not required for safety (see the close/reopen bypass fix above) — keep it only if you also want checks to re-run after a plain reopen with no new push. Documented in this repo's README; the caller template distributed by the GitHub App should mirror it.

## Migration note

Renames the check from **Merge Pull Request alert** to **Merge audit**. The old check was always red by construction (see Why above), so any repo requiring it as a status check would already have blocked every merge — the population doing so is expected to be zero. **The new name must never be configured as a required check** — it only reports after a PR is already merged/closed.

## Hotfix exception (added after policy discussion)

Business rule: **regular changes are merged only by Shoptet; urgent hotfixes may be merged by the partner** and reviewed retroactively. A partner-performed merge passes the audit when **both** hold:

- the head branch starts with `hotfix/` (`HOTFIX_BRANCH_PREFIX`),
- every changed file — including rename sources — lies inside `src/` (`HOTFIX_ALLOWED_PATH`), so no workflow, dependency or config changes can ride along.

A qualified hotfix gets a 🔥 comment mentioning the reviewer for **retroactive review**; anything else merged by a partner keeps failing, with the concrete reason in the comment (e.g. which files fall outside `src/`).

Verified on the sandbox repo:
- `hotfix/…` branch touching only `src/`, merged by the partner → audit **passes**, retro-review comment posted;
- `hotfix/…` branch touching `webpack.config.js`, merged by the partner → audit **fails**, comment names the offending file.

## What follows in the GitHub App (enforcement — this check is detection only)

A workflow in a partner-owned repository can *detect and flag*, but never *enforce*: the partner is admin of their own repo and can bypass or remove anything in it. The enforcement counterpart for the "only the service account may merge" policy belongs in `addon-repository-github-app`, which Shoptet fully controls:

1. **Deploy gate (the backbone):** before deploying a build to FTP, the App verifies that the deployed HEAD commit comes from a PR whose `merged_by` is the service account. A direct push to main or a merge performed by anyone else → **no deploy** + notification to the partner and to Shoptet. This is immune to the partner's repo plan and admin rights, and it is what gives this audit its teeth: the red "Merge audit" check tells the partner *why* their change did not reach the e-shop.
2. **Branch protection management (where the repo plan allows it):** on installation the App can create a "restrict who can push to main" rule listing only the service account, subscribe to `branch_protection_rule` webhooks, and re-apply + alert when a partner removes the rule. Note: branch protection is not enforced on private repos under the GitHub Free plan, which is why the deploy gate — not branch protection — is the primary enforcement layer.

## Coordination with #9

#9 rewrites `checks.workflow.yml` and currently carries the old `merge-check` job unchanged. Whichever PR lands second needs to carry this change over — the `merge-audit` job is self-contained and additive, so the rebase is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
