### PR TITLE
PR checks: count submitted reviews, protect the workflows directory, working concurrency

### DIFF
--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -13,6 +13,14 @@ permissions:
   checks: write
   pull-requests: write
 
+# Known, accepted race in the per-job concurrency groups below: GitHub queues
+# by the time a job *enters* the group, not by push order, so under runner
+# contention an older commit's job can enter later and cancel a newer
+# commit's in-progress job, stranding the newer (head) SHA with a `cancelled`
+# required check until someone manually re-runs it. This is the standard
+# `pr-<number>` + cancel-in-progress idiom; the race is rare and recoverable,
+# and dropping cancel-in-progress would bring back the runner pile-up this
+# job-level concurrency exists to fix — so it stays, with this on record.
 env:
   REQUIRED_REVIEWER: 'shoptet-addon-reviewer'
   # Entries ending with '/' protect the whole directory, anything else an exact file.
@@ -138,31 +146,37 @@ jobs:
 
             const requestedReviewers = pr.requested_reviewers.map(reviewer => reviewer.login);
             const requestedTeams = pr.requested_teams?.map(team => team.slug) || [];
+            const requiredReviewers = process.env.REQUIRED_REVIEWER.split(',').map(reviewer => reviewer.trim());
+
+            console.log('Required reviewers:', process.env.REQUIRED_REVIEWER);
+            console.log('Requested reviewers:', [...requestedReviewers, ...requestedTeams]);
+
+            let satisfied = [...requestedReviewers, ...requestedTeams];
+            let missingReviewers = requiredReviewers.filter(reviewer => !satisfied.includes(reviewer));
 
             // GitHub removes a reviewer from requested_reviewers the moment they
             // submit a review, so already-submitted reviews must count too —
-            // otherwise a re-run after an approval fails the check.
+            // otherwise a re-run after an approval fails the check. Only paginate
+            // listReviews when the requested-reviewers set doesn't already
+            // satisfy the check, since that's the common case on every push.
             // Deliberate consequence: any submitted review (even COMMENTED or a
             // later-dismissed one) satisfies this check permanently, regardless
             // of commits pushed afterwards. This check verifies "the reviewer
             // is in the loop"; merge enforcement itself lives in the merge
-            // audit and the App's deploy gate.
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
-            });
-            const submittedReviewers = [...new Set(reviews.map(review => review.user?.login).filter(Boolean))];
+            // audit (#10) and the App's deploy gate (addon-repository-github-app).
+            let submittedReviewers = [];
+            if (missingReviewers.length > 0) {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number
+              });
+              submittedReviewers = [...new Set(reviews.map(review => review.user?.login).filter(Boolean))];
+              satisfied = [...satisfied, ...submittedReviewers];
+              missingReviewers = requiredReviewers.filter(reviewer => !satisfied.includes(reviewer));
+            }
 
-            const satisfied = [...requestedReviewers, ...requestedTeams, ...submittedReviewers];
-
-            console.log('Required reviewers:', process.env.REQUIRED_REVIEWER);
-            console.log('Requested reviewers:', [...requestedReviewers, ...requestedTeams]);
             console.log('Submitted reviews from:', submittedReviewers);
-
-            const missingReviewers = process.env.REQUIRED_REVIEWER.split(',').filter(reviewer =>
-              !satisfied.includes(reviewer.trim())
-            );
 
             if (missingReviewers.length > 0) {
               console.error('Missing required reviewers:', missingReviewers);

--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -8,10 +8,6 @@ on:
         type: boolean
         default: false
 
-concurrency:
-  group: "pr-checks-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"
-  cancel-in-progress: true
-
 permissions:
   contents: read
   checks: write
@@ -19,12 +15,18 @@ permissions:
 
 env:
   REQUIRED_REVIEWER: 'shoptet-addon-reviewer'
-  PROTECTED_FILES: '.github/workflows/shoptetAddon.workflow.yml, .github/workflows/deploy.workflow.yml, .github/workflows/checks.workflow.yml'
+  # Entries ending with '/' protect the whole directory, anything else an exact file.
+  PROTECTED_PATHS: '.github/workflows/'
 
 jobs:
   review:
     name: Review Code
     runs-on: ubuntu-latest
+    # concurrency must sit at job level: GitHub ignores workflow-level
+    # concurrency in a reusable workflow invoked via workflow_call
+    concurrency:
+      group: "pr-checks-review-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"
+      cancel-in-progress: true
     steps:
       - name: Checkout addon code
         uses: actions/checkout@v6
@@ -53,6 +55,9 @@ jobs:
   merge-check:
     name: Merge Pull Request alert
     runs-on: ubuntu-latest
+    concurrency:
+      group: "pr-checks-merge-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"
+      cancel-in-progress: true
     steps:
       - name: Get PR author
         id: pr-info
@@ -75,6 +80,9 @@ jobs:
   files-check:
     name: File Protection Check
     runs-on: ubuntu-latest
+    concurrency:
+      group: "pr-checks-files-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"
+      cancel-in-progress: true
     permissions:
       checks: write
       pull-requests: read
@@ -90,8 +98,14 @@ jobs:
               pull_number: context.payload.pull_request.number
             });
 
+            const rules = process.env.PROTECTED_PATHS.split(',').map(rule => rule.trim()).filter(Boolean);
+            const isProtected = (name) => rules.some(rule =>
+              rule.endsWith('/') ? name.startsWith(rule) : name === rule
+            );
+
+            // previous_filename catches files renamed out of a protected path
             const changedProtectedFiles = files.filter(file =>
-              process.env.PROTECTED_FILES.split(',').map(f => f.trim()).includes(file.filename)
+              isProtected(file.filename) || (file.previous_filename && isProtected(file.previous_filename))
             );
 
             if (changedProtectedFiles.length > 0) {
@@ -104,6 +118,9 @@ jobs:
   collaborators-check:
     name: Shoptet reviewers assigned
     runs-on: ubuntu-latest
+    concurrency:
+      group: "pr-checks-collaborators-${{ github.repository_id }}-${{ github.event.pull_request.number || github.head_ref || github.ref_name }}"
+      cancel-in-progress: true
     permissions:
       checks: write
       pull-requests: read
@@ -121,18 +138,30 @@ jobs:
 
             const requestedReviewers = pr.requested_reviewers.map(reviewer => reviewer.login);
             const requestedTeams = pr.requested_teams?.map(team => team.slug) || [];
-            const allRequestedReviewers = [...requestedReviewers, ...requestedTeams];
+
+            // GitHub removes a reviewer from requested_reviewers the moment they
+            // submit a review, so already-submitted reviews must count too —
+            // otherwise a re-run after an approval fails the check.
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            const submittedReviewers = [...new Set(reviews.map(review => review.user?.login).filter(Boolean))];
+
+            const satisfied = [...requestedReviewers, ...requestedTeams, ...submittedReviewers];
 
             console.log('Required reviewers:', process.env.REQUIRED_REVIEWER);
-            console.log('Requested reviewers:', allRequestedReviewers);
+            console.log('Requested reviewers:', [...requestedReviewers, ...requestedTeams]);
+            console.log('Submitted reviews from:', submittedReviewers);
 
             const missingReviewers = process.env.REQUIRED_REVIEWER.split(',').filter(reviewer =>
-              !allRequestedReviewers.includes(reviewer.trim())
+              !satisfied.includes(reviewer.trim())
             );
 
             if (missingReviewers.length > 0) {
               console.error('Missing required reviewers:', missingReviewers);
               process.exit(1);
             } else {
-              console.log('All required reviewers assigned');
+              console.log('All required reviewers assigned or already reviewed');
             }

--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -142,6 +142,11 @@ jobs:
             // GitHub removes a reviewer from requested_reviewers the moment they
             // submit a review, so already-submitted reviews must count too —
             // otherwise a re-run after an approval fails the check.
+            // Deliberate consequence: any submitted review (even COMMENTED or a
+            // later-dismissed one) satisfies this check permanently, regardless
+            // of commits pushed afterwards. This check verifies "the reviewer
+            // is in the loop"; merge enforcement itself lives in the merge
+            // audit and the App's deploy gate.
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,6 @@ jobs:
           persist-credentials: false
       - name: Run tests
         run: bash tests/test-workflow-scripts.sh
+
+      - name: Run checks workflow script tests
+        run: bash tests/test-checks-workflow-scripts.sh

--- a/tests/run-github-script.js
+++ b/tests/run-github-script.js
@@ -1,0 +1,54 @@
+// Executes a github-script block extracted from a workflow YAML with mocked
+// `github` / `context` / `core`, so the embedded logic is testable offline.
+//
+// Usage: node run-github-script.js <script.js> <fixture.json>
+//
+// Fixture shape:
+//   env      — extra process.env entries (PROTECTED_PATHS, REQUIRED_REVIEWER, …)
+//   pr       — the pull request object (returned by pulls.get, also used as
+//              context.payload.pull_request)
+//   files    — array returned when the script paginates pulls.listFiles
+//   reviews  — array returned when the script paginates pulls.listReviews
+//
+// The exit code is the test result: scripts signal failure via process.exit(1)
+// or core.setFailed, success by finishing normally.
+const fs = require('fs');
+
+const [, , scriptPath, fixturePath] = process.argv;
+const script = fs.readFileSync(scriptPath, 'utf8');
+const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+
+Object.assign(process.env, fixture.env || {});
+
+// Paginated endpoints carry their fixture data on the function object so the
+// paginate mock can return it regardless of which endpoint is passed in.
+const paged = (data) => Object.assign(async () => ({ data }), { __page: data });
+const github = {
+  rest: {
+    pulls: {
+      get: async () => ({ data: fixture.pr }),
+      listFiles: paged(fixture.files || []),
+      listReviews: paged(fixture.reviews || []),
+    },
+    issues: {
+      listComments: paged(fixture.comments || []),
+      createComment: async () => ({}),
+    },
+  },
+  paginate: async (endpoint) => endpoint.__page ?? [],
+};
+
+const context = {
+  repo: { owner: 'test-owner', repo: 'test-repo' },
+  payload: { pull_request: fixture.pr },
+};
+
+const core = {
+  setFailed: (message) => { console.error(message); process.exitCode = 1; },
+  setOutput: () => {},
+  warning: (message) => console.warn(message),
+};
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+new AsyncFunction('github', 'context', 'core', script)(github, context, core)
+  .catch((error) => { console.error(error.message); process.exit(1); });

--- a/tests/run-github-script.js
+++ b/tests/run-github-script.js
@@ -13,44 +13,47 @@
 // The exit code is the test result: 0 = the script finished normally,
 // 1 = the script signalled a policy failure (process.exit(1) / core.setFailed),
 // 2 = the script crashed (thrown error) — a crash must never satisfy a test
-// that expects a policy failure.
+// that expects a policy failure. Everything that can throw — reading the
+// fixture, compiling the extracted script, running it — happens inside the
+// same .then(), so a syntax error or a malformed fixture is a crash (exit 2)
+// too, not a false pass on an expected_exit=1 case.
 const fs = require('fs');
 
-const [, , scriptPath, fixturePath] = process.argv;
-const script = fs.readFileSync(scriptPath, 'utf8');
-const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
-
-Object.assign(process.env, fixture.env || {});
-
-// Paginated endpoints carry their fixture data on the function object so the
-// paginate mock can return it regardless of which endpoint is passed in.
-const paged = (data) => Object.assign(async () => ({ data }), { __page: data });
-const github = {
-  rest: {
-    pulls: {
-      get: async () => ({ data: fixture.pr }),
-      listFiles: paged(fixture.files || []),
-      listReviews: paged(fixture.reviews || []),
-    },
-    issues: {
-      listComments: paged(fixture.comments || []),
-      createComment: async () => ({}),
-    },
-  },
-  paginate: async (endpoint) => endpoint.__page ?? [],
-};
-
-const context = {
-  repo: { owner: 'test-owner', repo: 'test-repo' },
-  payload: { pull_request: fixture.pr },
-};
-
-const core = {
-  setFailed: (message) => { console.error(message); process.exitCode = 1; },
-  setOutput: () => {},
-  warning: (message) => console.warn(message),
-};
-
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-new AsyncFunction('github', 'context', 'core', script)(github, context, core)
-  .catch((error) => { console.error(error.stack ?? error.message); process.exit(2); });
+
+Promise.resolve().then(() => {
+  const [, , scriptPath, fixturePath] = process.argv;
+  const script = fs.readFileSync(scriptPath, 'utf8');
+  const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+
+  Object.assign(process.env, fixture.env || {});
+
+  const paged = (data) => async () => ({ data });
+  const github = {
+    rest: {
+      pulls: {
+        get: async () => ({ data: fixture.pr }),
+        listFiles: paged(fixture.files || []),
+        listReviews: paged(fixture.reviews || []),
+      },
+      issues: {
+        listComments: paged(fixture.comments || []),
+        createComment: async () => ({}),
+      },
+    },
+    paginate: async (endpoint) => (await endpoint()).data,
+  };
+
+  const context = {
+    repo: { owner: 'test-owner', repo: 'test-repo' },
+    payload: { pull_request: fixture.pr },
+  };
+
+  const core = {
+    setFailed: (message) => { console.error(message); process.exitCode = 1; },
+    setOutput: () => {},
+    warning: (message) => console.warn(message),
+  };
+
+  return new AsyncFunction('github', 'context', 'core', script)(github, context, core);
+}).catch((error) => { console.error(error.stack ?? error.message); process.exit(2); });

--- a/tests/run-github-script.js
+++ b/tests/run-github-script.js
@@ -10,8 +10,10 @@
 //   files    — array returned when the script paginates pulls.listFiles
 //   reviews  — array returned when the script paginates pulls.listReviews
 //
-// The exit code is the test result: scripts signal failure via process.exit(1)
-// or core.setFailed, success by finishing normally.
+// The exit code is the test result: 0 = the script finished normally,
+// 1 = the script signalled a policy failure (process.exit(1) / core.setFailed),
+// 2 = the script crashed (thrown error) — a crash must never satisfy a test
+// that expects a policy failure.
 const fs = require('fs');
 
 const [, , scriptPath, fixturePath] = process.argv;
@@ -51,4 +53,4 @@ const core = {
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 new AsyncFunction('github', 'context', 'core', script)(github, context, core)
-  .catch((error) => { console.error(error.message); process.exit(1); });
+  .catch((error) => { console.error(error.stack ?? error.message); process.exit(2); });

--- a/tests/test-checks-workflow-scripts.sh
+++ b/tests/test-checks-workflow-scripts.sh
@@ -25,14 +25,19 @@ File.write(collab_js, grab.call("collaborators-check", "Check required reviewers
 
 PASS=0
 FAIL=0
-run_case() { # name script fixture expected_exit
-  local name="$1" script="$2" fixture="$3" expected="$4" actual
-  if node "$RUNNER" "$script" "$fixture" >"$TMP/out.log" 2>&1; then actual=0; else actual=1; fi
-  if [ "$actual" = "$expected" ]; then
-    echo "PASS: $name"; PASS=$((PASS + 1))
-  else
-    echo "FAIL: $name (exit $actual, expected $expected)"; sed 's/^/    /' "$TMP/out.log"; FAIL=$((FAIL + 1))
+run_case() { # name script fixture expected_exit [expected_log_pattern]
+  # The exact exit code matters: the runner exits 2 on a script crash, so a
+  # crash can never satisfy an expected_exit=1 (policy failure) case. The
+  # optional pattern pins down *why* a deny case failed.
+  local name="$1" script="$2" fixture="$3" expected="$4" pattern="${5:-}" actual
+  node "$RUNNER" "$script" "$fixture" >"$TMP/out.log" 2>&1; actual=$?
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL: $name (exit $actual, expected $expected)"; sed 's/^/    /' "$TMP/out.log"; FAIL=$((FAIL + 1)); return
   fi
+  if [ -n "$pattern" ] && ! grep -q "$pattern" "$TMP/out.log"; then
+    echo "FAIL: $name — log does not contain: $pattern"; sed 's/^/    /' "$TMP/out.log"; FAIL=$((FAIL + 1)); return
+  fi
+  echo "PASS: $name"; PASS=$((PASS + 1))
 }
 
 ### files-check — directory prefix + exact-file rules, renames
@@ -49,21 +54,21 @@ cat > "$TMP/f2.json" <<'EOF'
   "pr": { "number": 1 },
   "files": [ { "filename": ".github/workflows/brand-new.yml" } ] }
 EOF
-run_case "new file inside protected directory fails" "$TMP/files.js" "$TMP/f2.json" 1
+run_case "new file inside protected directory fails" "$TMP/files.js" "$TMP/f2.json" 1 'Protected files changed'
 
 cat > "$TMP/f3.json" <<'EOF'
 { "env": { "PROTECTED_PATHS": ".github/workflows/" },
   "pr": { "number": 1 },
   "files": [ { "filename": "renamed-elsewhere.yml", "previous_filename": ".github/workflows/shoptetAddon.workflow.yml" } ] }
 EOF
-run_case "rename out of protected directory fails" "$TMP/files.js" "$TMP/f3.json" 1
+run_case "rename out of protected directory fails" "$TMP/files.js" "$TMP/f3.json" 1 'Protected files changed'
 
 cat > "$TMP/f4.json" <<'EOF'
 { "env": { "PROTECTED_PATHS": ".github/workflows/, config.json" },
   "pr": { "number": 1 },
   "files": [ { "filename": "config.json" } ] }
 EOF
-run_case "exact-file rule fails on that file" "$TMP/files.js" "$TMP/f4.json" 1
+run_case "exact-file rule fails on that file" "$TMP/files.js" "$TMP/f4.json" 1 'Protected files changed'
 
 cat > "$TMP/f5.json" <<'EOF'
 { "env": { "PROTECTED_PATHS": ".github/workflows/, config.json" },
@@ -86,7 +91,7 @@ cat > "$TMP/c2.json" <<'EOF'
   "pr": { "number": 1, "requested_reviewers": [], "requested_teams": [] },
   "reviews": [] }
 EOF
-run_case "no request and no review fails" "$TMP/collab.js" "$TMP/c2.json" 1
+run_case "no request and no review fails" "$TMP/collab.js" "$TMP/c2.json" 1 'Missing required reviewers'
 
 cat > "$TMP/c3.json" <<'EOF'
 { "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer" },
@@ -101,7 +106,7 @@ cat > "$TMP/c4.json" <<'EOF'
   "reviews": [ { "user": { "login": "someone-else" }, "state": "APPROVED" },
                { "user": null, "state": "COMMENTED" } ] }
 EOF
-run_case "review by someone else does not count" "$TMP/collab.js" "$TMP/c4.json" 1
+run_case "review by someone else does not count" "$TMP/collab.js" "$TMP/c4.json" 1 'Missing required reviewers'
 
 cat > "$TMP/c5.json" <<'EOF'
 { "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer, second-reviewer" },

--- a/tests/test-checks-workflow-scripts.sh
+++ b/tests/test-checks-workflow-scripts.sh
@@ -21,7 +21,7 @@ grab = ->(job, step) {
 }
 File.write(files_js, grab.call("files-check", "Check protected files"))
 File.write(collab_js, grab.call("collaborators-check", "Check required reviewers"))
-' "$WORKFLOW" "$TMP/files.js" "$TMP/collab.js"
+' "$WORKFLOW" "$TMP/files.js" "$TMP/collab.js" || exit 1
 
 PASS=0
 FAIL=0
@@ -114,6 +114,20 @@ cat > "$TMP/c5.json" <<'EOF'
   "reviews": [ { "user": { "login": "shoptet-addon-reviewer" }, "state": "COMMENTED" } ] }
 EOF
 run_case "multiple required reviewers combine request + review" "$TMP/collab.js" "$TMP/c5.json" 0
+
+cat > "$TMP/c6.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer" },
+  "pr": { "number": 1, "requested_reviewers": [], "requested_teams": [] },
+  "reviews": [ { "user": { "login": "shoptet-addon-reviewer" }, "state": "CHANGES_REQUESTED" } ] }
+EOF
+run_case "a CHANGES_REQUESTED review still counts (deliberate)" "$TMP/collab.js" "$TMP/c6.json" 0
+
+cat > "$TMP/c7.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer" },
+  "pr": { "number": 1, "requested_reviewers": [], "requested_teams": [] },
+  "reviews": [ { "user": { "login": "shoptet-addon-reviewer" }, "state": "DISMISSED" } ] }
+EOF
+run_case "a later-dismissed review still counts (deliberate)" "$TMP/collab.js" "$TMP/c7.json" 0
 
 echo
 echo "=== $PASS passed, $FAIL failed ==="

--- a/tests/test-checks-workflow-scripts.sh
+++ b/tests/test-checks-workflow-scripts.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Tests for the github-script blocks embedded in .github/workflows/checks.workflow.yml.
+# The scripts are extracted from the YAML itself (same approach as
+# test-workflow-scripts.sh), so the tests always exercise exactly what the
+# workflow runs. Requires: bash, ruby (yaml), node.
+set -u
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+WORKFLOW="$ROOT/.github/workflows/checks.workflow.yml"
+RUNNER="$ROOT/tests/run-github-script.js"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+ruby -ryaml -e '
+wf, files_js, collab_js = ARGV
+jobs = YAML.load_file(wf)["jobs"]
+grab = ->(job, step) {
+  s = jobs.fetch(job) { abort "Job \"#{job}\" not found — renamed? Update tests/test-checks-workflow-scripts.sh." }["steps"]
+        .find { |st| st["name"] == step } or abort "Step \"#{step}\" not found in job \"#{job}\"."
+  s["with"]["script"]
+}
+File.write(files_js, grab.call("files-check", "Check protected files"))
+File.write(collab_js, grab.call("collaborators-check", "Check required reviewers"))
+' "$WORKFLOW" "$TMP/files.js" "$TMP/collab.js"
+
+PASS=0
+FAIL=0
+run_case() { # name script fixture expected_exit
+  local name="$1" script="$2" fixture="$3" expected="$4" actual
+  if node "$RUNNER" "$script" "$fixture" >"$TMP/out.log" 2>&1; then actual=0; else actual=1; fi
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $actual, expected $expected)"; sed 's/^/    /' "$TMP/out.log"; FAIL=$((FAIL + 1))
+  fi
+}
+
+### files-check — directory prefix + exact-file rules, renames
+
+cat > "$TMP/f1.json" <<'EOF'
+{ "env": { "PROTECTED_PATHS": ".github/workflows/" },
+  "pr": { "number": 1 },
+  "files": [ { "filename": "src/header/script.js" }, { "filename": "src/style.less" } ] }
+EOF
+run_case "src-only change passes" "$TMP/files.js" "$TMP/f1.json" 0
+
+cat > "$TMP/f2.json" <<'EOF'
+{ "env": { "PROTECTED_PATHS": ".github/workflows/" },
+  "pr": { "number": 1 },
+  "files": [ { "filename": ".github/workflows/brand-new.yml" } ] }
+EOF
+run_case "new file inside protected directory fails" "$TMP/files.js" "$TMP/f2.json" 1
+
+cat > "$TMP/f3.json" <<'EOF'
+{ "env": { "PROTECTED_PATHS": ".github/workflows/" },
+  "pr": { "number": 1 },
+  "files": [ { "filename": "renamed-elsewhere.yml", "previous_filename": ".github/workflows/shoptetAddon.workflow.yml" } ] }
+EOF
+run_case "rename out of protected directory fails" "$TMP/files.js" "$TMP/f3.json" 1
+
+cat > "$TMP/f4.json" <<'EOF'
+{ "env": { "PROTECTED_PATHS": ".github/workflows/, config.json" },
+  "pr": { "number": 1 },
+  "files": [ { "filename": "config.json" } ] }
+EOF
+run_case "exact-file rule fails on that file" "$TMP/files.js" "$TMP/f4.json" 1
+
+cat > "$TMP/f5.json" <<'EOF'
+{ "env": { "PROTECTED_PATHS": ".github/workflows/, config.json" },
+  "pr": { "number": 1 },
+  "files": [ { "filename": "config.json.example" } ] }
+EOF
+run_case "exact-file rule is not a prefix match" "$TMP/files.js" "$TMP/f5.json" 0
+
+### collaborators-check — requested reviewers + submitted reviews
+
+cat > "$TMP/c1.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer" },
+  "pr": { "number": 1, "requested_reviewers": [ { "login": "shoptet-addon-reviewer" } ], "requested_teams": [] },
+  "reviews": [] }
+EOF
+run_case "requested reviewer passes" "$TMP/collab.js" "$TMP/c1.json" 0
+
+cat > "$TMP/c2.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer" },
+  "pr": { "number": 1, "requested_reviewers": [], "requested_teams": [] },
+  "reviews": [] }
+EOF
+run_case "no request and no review fails" "$TMP/collab.js" "$TMP/c2.json" 1
+
+cat > "$TMP/c3.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer" },
+  "pr": { "number": 1, "requested_reviewers": [], "requested_teams": [] },
+  "reviews": [ { "user": { "login": "shoptet-addon-reviewer" }, "state": "APPROVED" } ] }
+EOF
+run_case "submitted review counts (approve + later push)" "$TMP/collab.js" "$TMP/c3.json" 0
+
+cat > "$TMP/c4.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer" },
+  "pr": { "number": 1, "requested_reviewers": [], "requested_teams": [] },
+  "reviews": [ { "user": { "login": "someone-else" }, "state": "APPROVED" },
+               { "user": null, "state": "COMMENTED" } ] }
+EOF
+run_case "review by someone else does not count" "$TMP/collab.js" "$TMP/c4.json" 1
+
+cat > "$TMP/c5.json" <<'EOF'
+{ "env": { "REQUIRED_REVIEWER": "shoptet-addon-reviewer, second-reviewer" },
+  "pr": { "number": 1, "requested_reviewers": [ { "login": "second-reviewer" } ], "requested_teams": [] },
+  "reviews": [ { "user": { "login": "shoptet-addon-reviewer" }, "state": "COMMENTED" } ] }
+EOF
+run_case "multiple required reviewers combine request + review" "$TMP/collab.js" "$TMP/c5.json" 0
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" = "0" ]


### PR DESCRIPTION
Three fixes to `checks.workflow.yml`, each addressing a defect confirmed live during the July sandbox E2E test and re-verified on the sandbox partner repo with this exact change.

## 1. `collaborators-check` failed right after an approval

GitHub removes a reviewer from `requested_reviewers` the moment they submit a review. So the sequence *request review → reviewer approves → push another commit* turned the "Shoptet reviewers assigned" check red — it failed precisely when the process worked correctly. The check now also counts **already-submitted reviews** (`pulls.listReviews`, paginated): a required reviewer satisfies the check when they are either currently requested **or** have already reviewed.

**Verified:** approve + follow-up push now keeps the check green (run log shows `Submitted reviews from: shoptet-addon-reviewer`).

## 2. File protection could be bypassed with a new workflow file

The protection compared changed paths against an exact-filename list, so a PR *adding* a brand-new file under `.github/workflows/` (which the checks pipeline never invokes) sailed through. The `PROTECTED_FILES` env is replaced by **`PROTECTED_PATHS`**: entries ending with `/` protect the whole directory (prefix match), anything else stays an exact file — and `previous_filename` is checked too, so renaming a file out of a protected path is caught as well.

**Verified:** a PR adding `.github/workflows/bypass2.yml` now fails File Protection Check; a PR touching only `src/` still passes.

> Note for callers/docs: anything referring to the old `PROTECTED_FILES` name needs updating.

## 3. Workflow-level `concurrency` never worked

GitHub ignores workflow-level `concurrency` in a reusable workflow invoked via `workflow_call`, so superseded runs were never cancelled and rapid pushes piled up runners. Concurrency is moved to **job level** (which *is* honored in called workflows), with per-job group names so jobs of the same run don't cancel each other.

**Verified:** two pushes 4 s apart — the first run ends `cancelled`, the second completes.

## Coordination

- **#9** rewrites this same file — whichever lands second carries these changes over (all three are self-contained: one script block, one env + script block, four `concurrency` blocks).
- **#10** replaces the `merge-check` job in this same file; this PR deliberately leaves `merge-check` untouched to keep the two changes independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
