### PR TITLE
Scope merge-audit to PRs merged into the default branch

### DIFF
--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -34,14 +34,16 @@ env:
 jobs:
   review:
     name: Review Code
-    # Skip only on closed+merged (merge-audit takes over from there). A
-    # closed-without-merge event still runs this job normally, so the real
-    # pass/fail status gets re-posted on the SAME event that closed the PR —
-    # this is what closes the close/reopen bypass a caller could otherwise
-    # hit by adding `closed` to its trigger types without `reopened`: a
-    # `skipped` conclusion counts as passing for required-status purposes,
-    # so skipping on every closed action (merged or not) would let a partner
-    # close a PR blocked by a red check and reopen it green.
+    # Skip only on closed+merged (merge-audit takes over from there, for a
+    # PR merged into main/master — a merge into any other branch intentionally
+    # runs nothing at all, see merge-audit's own if: below). A closed-without-
+    # merge event still runs this job normally, so the real pass/fail status
+    # gets re-posted on the SAME event that closed the PR — this is what
+    # closes the close/reopen bypass a caller could otherwise hit by adding
+    # `closed` to its trigger types without `reopened`: a `skipped` conclusion
+    # counts as passing for required-status purposes, so skipping on every
+    # closed action (merged or not) would let a partner close a PR blocked by
+    # a red check and reopen it green.
     if: github.event.action != 'closed' || github.event.pull_request.merged != true
     runs-on: ubuntu-latest
     # concurrency must sit at job level: GitHub ignores workflow-level
@@ -88,11 +90,24 @@ jobs:
     # this job never runs. No event_name check: no other event carries a
     # truthy github.event.pull_request.merged, and gating on 'pull_request'
     # specifically would silently skip this job for pull_request_target callers.
-    # Scoped to the default branch: this check encodes "who may merge code
-    # that reaches production", so a PR merged between two non-default
-    # branches (partners managing their own feature/release branches) must
-    # not trigger it — that would misfire on merges nobody needs reviewed.
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch
+    # Scoped to main/master, NOT github.event.repository.default_branch:
+    # this check encodes "who may merge code that reaches production", and
+    # default_branch is a partner-editable Settings value with no commit
+    # trail — a partner could point it at a throwaway branch, self-merge
+    # unreviewed code into main, then point it back, and the audit would
+    # skip silently (no red check, no comment) for that PR forever. A repo
+    # whose real default branch simply isn't named main/master would also
+    # go permanently unaudited under the default_branch condition, silently
+    # and by default rather than as a deliberate attack. main/master is what
+    # actually deploys: it's the exact branch list the App's distributed
+    # deploy template (assets/shoptetAddon.workflow.yml in
+    # addon-repository-github-app) hardcodes as its `push` trigger, so this
+    # tracks the real deploy path instead of a value the audited party
+    # controls. `contains()` here does a case-insensitive match (same as
+    # Actions' `==`), so a partner merging into a same-named branch that
+    # differs only by case (e.g. `Main`) still trips this — accepted edge,
+    # not worth a shell-level case-sensitive workaround.
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && contains(fromJSON('["main", "master"]'), github.event.pull_request.base.ref)
     runs-on: ubuntu-latest
     # No cancel-in-progress: the closed+merged event fires once per PR
     # lifetime under a single trigger, so there is normally nothing to

--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -88,7 +88,11 @@ jobs:
     # this job never runs. No event_name check: no other event carries a
     # truthy github.event.pull_request.merged, and gating on 'pull_request'
     # specifically would silently skip this job for pull_request_target callers.
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    # Scoped to the default branch: this check encodes "who may merge code
+    # that reaches production", so a PR merged between two non-default
+    # branches (partners managing their own feature/release branches) must
+    # not trigger it — that would misfire on merges nobody needs reviewed.
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     # No cancel-in-progress: the closed+merged event fires once per PR
     # lifetime under a single trigger, so there is normally nothing to

--- a/.github/workflows/checks.workflow.yml
+++ b/.github/workflows/checks.workflow.yml
@@ -316,8 +316,10 @@ jobs:
             // Deliberate consequence: any submitted review (even COMMENTED or a
             // later-dismissed one) satisfies this check permanently, regardless
             // of commits pushed afterwards. This check verifies "the reviewer
-            // is in the loop"; merge enforcement itself lives in the merge
-            // audit (#10) and the App's deploy gate (addon-repository-github-app).
+            // is in the loop"; merge enforcement for production-bound code
+            // lives in the merge audit (#10) and the App's deploy gate
+            // (addon-repository-github-app) — neither backstop fires for a
+            // PR merged into a branch other than main/master.
             let submittedReviewers = [];
             if (missingReviewers.length > 0) {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The resolved package manager is used for the `setup-node` dependency cache, the 
 
 ## Pull request checks
 
-`checks.workflow.yml` runs code review, protected-path and required-reviewer checks on every PR, plus a post-merge `merge-audit` job that flags a merge into the repo's default branch performed by anyone other than `REQUIRED_REVIEWER` (with a retroactive-review exception for `hotfix/*` branches touching only `src/`). Call it with:
+`checks.workflow.yml` runs code review, protected-path and required-reviewer checks on every PR, plus a post-merge `merge-audit` job that flags a merge into `main` or `master` performed by anyone other than `REQUIRED_REVIEWER` (with a retroactive-review exception for `hotfix/*` branches touching only `src/`). Scoped to `main`/`master` rather than the repo's (partner-editable) default branch setting, to track the branch that actually deploys. Call it with:
 
 ```yaml
 on:
@@ -48,7 +48,7 @@ jobs:
     uses: shoptet/addon-repository-actions-config/.github/workflows/checks.workflow.yml@main
 ```
 
-`closed` must be in the caller's trigger types — GitHub's default (`[opened, synchronize, reopened]`) never fires it — or `merge-audit` never runs and merges go unaudited. `reopened` is not required for safety: the review/files/collaborators jobs re-run on a closed-but-unmerged event too, so a partner cannot close a PR blocked by a red check and reopen it past a stale green one; keep `reopened` only if you also want checks to re-run after a partner reopens a closed PR without a new push.
+`closed` must be in the caller's trigger types — GitHub's default (`[opened, synchronize, reopened]`) never fires it — or `merge-audit` never runs and merges go unaudited (a merge into a branch other than `main`/`master` is never audited regardless of trigger types — see above). `reopened` is not required for safety: the review/files/collaborators jobs re-run on a closed-but-unmerged event too, so a partner cannot close a PR blocked by a red check and reopen it past a stale green one; keep `reopened` only if you also want checks to re-run after a partner reopens a closed PR without a new push.
 
 The `permissions` block matters: a restrictive org/repo default token (`contents: read` only) grants less than the workflow requests, and the merge-audit comment step degrades silently to a warning instead of failing the run — on a qualifying hotfix that means a green check with no retroactive-review ping at all. Declare only one of `pull_request` / `pull_request_target` with `closed` — declaring both fires `merge-audit` twice per merge; the job's own concurrency group queues (not cancels) a duplicate run so it detects the first run's comment instead of double-posting, but there is no reason to wire it that way.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The resolved package manager is used for the `setup-node` dependency cache, the 
 
 ## Pull request checks
 
-`checks.workflow.yml` runs code review, protected-path and required-reviewer checks on every PR, plus a post-merge `merge-audit` job that flags a merge performed by anyone other than `REQUIRED_REVIEWER` (with a retroactive-review exception for `hotfix/*` branches touching only `src/`). Call it with:
+`checks.workflow.yml` runs code review, protected-path and required-reviewer checks on every PR, plus a post-merge `merge-audit` job that flags a merge into the repo's default branch performed by anyone other than `REQUIRED_REVIEWER` (with a retroactive-review exception for `hotfix/*` branches touching only `src/`). Call it with:
 
 ```yaml
 on:


### PR DESCRIPTION
## Why

`merge-audit` (#10) currently fires on any `closed && merged` pull_request event, regardless of which branch the PR merged into. Since it encodes "who may merge code that reaches production," it should only ever apply to PRs merged into a branch that actually deploys.

Nothing in the caller wiring restricts this today — neither the old caller asset nor the `checks.workflow.yml` caller template drafted in `addon-repository-github-app`#46 filters `pull_request` events by base branch. So a partner managing their own feature/release branches (merging PR A into PR B's branch, say) would trip the audit and get a false "this pull request was merged by @partner, who is not a Shoptet reviewer" comment on a merge nobody needs reviewed.

## What this PR changes

Adds a `main`/`master` guard to `merge-audit`'s `if:` condition — `contains(fromJSON('["main", "master"]'), github.event.pull_request.base.ref)` — matching the exact branch list the App's distributed deploy template (`assets/shoptetAddon.workflow.yml`) hardcodes as its `push` trigger. Originally anchored on `github.event.repository.default_branch` instead; switched during review (see below) since that's a partner-editable Settings value with no commit trail, unlike main/master. No change to `review`/`files-check`/`collaborators-check` — those aren't scoped to this fix; whether they should get the same treatment is a separate question.

Accepted trade-off: a partner assembling a hotfix from several internal PRs onto a `hotfix/*` branch no longer gets interim red checks on those internal merges (they target neither main nor master). Review isn't evaded — the final `hotfix/* → main/master` merge still triggers the full merge-audit pass with the complete assembled diff, flagged for retroactive review — but the early warning that used to fire on each internal merge is gone.

## Provenance

Flagged in `addon-repository-github-app`#46 (deploy-gate work, unmerged) as a consistency gap between the workflow-side detection here and the App-side enforcement gate: "the workflow-side audit in actions-config needs the matching base.ref condition so both layers stay consistent."

## Review

TomasHermanSnowlyCode reviewed 2026-08-26: 1 blocker (`default_branch` is partner-editable state with no commit trail and no tie to what actually deploys — confirmed via `default.workflow.yml`, which builds whatever ref triggered it, no branch pinning), 1 warning (stale invariant comment), 4 nits. Fixed in `fe15dd1` (main/master anchor + the four inline nits) and `cd428a6` (collaborators-check wording). Approved 2026-08-27, with independent verification that the App's distributed deploy template does hardcode `push: branches: [main, master]`.

The same `default_branch` anchor exists on the App side (`createMergeAuditCheck` in #46, `evaluateDeployGate` in #44) and hasn't shipped yet — flagged there: shoptet/addon-repository-github-app#46 (comment).

## Verification

`tests/test-checks-workflow-scripts.sh` (22/22) and `tests/test-workflow-scripts.sh` (105/105) pass; actionlint clean. This guard isn't unit-testable by the existing harness — same limitation as the close/reopen-bypass fix in #10, which tests the extracted `github-script` bodies, not job-level `if:` conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
